### PR TITLE
Include raw response body on json parse errors

### DIFF
--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -209,9 +209,11 @@ var _ = require('lodash'),
 
             externalLoader('collection', value, options, function (err, data) {
                 if (err) {
-                    return done(new Error(COLLECTION_LOAD_ERROR_MESSAGE +
+                    var newErr = new Error(COLLECTION_LOAD_ERROR_MESSAGE +
                         (err.help ? `\n  ${err.help}` : '') +
-                        `\n  ${err.message || err}`));
+                        `\n  ${err.message || err}`);
+                    newErr.prevErr = err;
+                    return done(newErr);
                 }
                 if (!_.isObject(data)) {
                     return done(new Error(COLLECTION_LOAD_ERROR_MESSAGE));

--- a/lib/util.js
+++ b/lib/util.js
@@ -183,7 +183,9 @@ util = {
                     _.isString(body) && (body = liquidJSON.parse(body.trim()));
                 }
                 catch (e) {
-                    return callback(_.set(e, 'help', `the url "${location}" did not provide valid JSON data`));
+                    _.set(e, 'help', `the url "${location}" did not provide valid JSON data`)
+                    _.set(e, 'rawBody', body)
+                    return callback(e);
                 }
 
                 var error,


### PR DESCRIPTION
In the case of a json parse error when loading a collection, includes the raw response body through an embedded previous error.